### PR TITLE
feat: adds MCP prompt for pokemon comparison, add support for using it end-to-end in example.

### DIFF
--- a/mcp-pokemon/src/index.ts
+++ b/mcp-pokemon/src/index.ts
@@ -13,11 +13,13 @@ import { logger } from './logger.js';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  type Tool,
-  type CallToolResult,
-  type CallToolRequest
+    ListPromptsRequestSchema,
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+    type Tool,
+    type CallToolResult,
+    type CallToolRequest,
+    GetPromptRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
 import { setupStreamableHttpServer } from "./streamable-http.js";
 
@@ -36,189 +38,189 @@ type JsonObject = Record<string, any>;
  * Reduces token count by ~40-50% compared to raw JSON response
  */
 function summarizePokemon(data: any): JsonObject {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
+    if (!data || typeof data !== 'object') {
+        return data;
+    }
 
-  // Extract basic fields
-  const summary: JsonObject = {
-    id: data.id,
-    name: data.name,
-    height: data.height,
-    weight: data.weight,
-  };
-
-  // Extract types (array: [{name, slot}])
-  if (Array.isArray(data.types)) {
-    summary.types = data.types.map((t: any) => ({
-      name: t.type?.name || t.name || '',
-      slot: t.slot || 0,
-    }));
-  }
-
-  // Extract base stats (array: [{stat, base_stat}])
-  if (Array.isArray(data.stats)) {
-    summary.stats = data.stats.map((s: any) => ({
-      stat: s.stat?.name || s.stat || '',
-      base_stat: s.base_stat || 0,
-    }));
-  }
-
-  // Extract abilities (array: [{name, is_hidden}])
-  if (Array.isArray(data.abilities)) {
-    summary.abilities = data.abilities.map((a: any) => ({
-      name: a.ability?.name || a.name || '',
-      is_hidden: a.is_hidden || false,
-    }));
-  }
-
-  // Extract moves (limit to first 10, array: [{name}])
-  if (Array.isArray(data.moves)) {
-    // Sort by learn method preference: level-up > egg > machine > others
-    const moveMethodOrder: Record<string, number> = {
-      'level-up': 0,
-      'egg': 1,
-      'machine': 2,
-      'tutor': 3,
+    // Extract basic fields
+    const summary: JsonObject = {
+        id: data.id,
+        name: data.name,
+        height: data.height,
+        weight: data.weight,
     };
 
-    const sortedMoves = [...data.moves].sort((a: any, b: any) => {
-      const aMethod = a.version_group_details?.[0]?.move_learn_method?.name || 'other';
-      const bMethod = b.version_group_details?.[0]?.move_learn_method?.name || 'other';
-      return (moveMethodOrder[aMethod] ?? 999) - (moveMethodOrder[bMethod] ?? 999);
-    });
+    // Extract types (array: [{name, slot}])
+    if (Array.isArray(data.types)) {
+        summary.types = data.types.map((t: any) => ({
+            name: t.type?.name || t.name || '',
+            slot: t.slot || 0,
+        }));
+    }
 
-    summary.moves = sortedMoves.slice(0, 10).map((m: any) => ({
-      name: m.move?.name || m.name || '',
-    }));
-  }
+    // Extract base stats (array: [{stat, base_stat}])
+    if (Array.isArray(data.stats)) {
+        summary.stats = data.stats.map((s: any) => ({
+            stat: s.stat?.name || s.stat || '',
+            base_stat: s.base_stat || 0,
+        }));
+    }
 
-  return summary;
+    // Extract abilities (array: [{name, is_hidden}])
+    if (Array.isArray(data.abilities)) {
+        summary.abilities = data.abilities.map((a: any) => ({
+            name: a.ability?.name || a.name || '',
+            is_hidden: a.is_hidden || false,
+        }));
+    }
+
+    // Extract moves (limit to first 10, array: [{name}])
+    if (Array.isArray(data.moves)) {
+        // Sort by learn method preference: level-up > egg > machine > others
+        const moveMethodOrder: Record<string, number> = {
+            'level-up': 0,
+            'egg': 1,
+            'machine': 2,
+            'tutor': 3,
+        };
+
+        const sortedMoves = [...data.moves].sort((a: any, b: any) => {
+            const aMethod = a.version_group_details?.[0]?.move_learn_method?.name || 'other';
+            const bMethod = b.version_group_details?.[0]?.move_learn_method?.name || 'other';
+            return (moveMethodOrder[aMethod] ?? 999) - (moveMethodOrder[bMethod] ?? 999);
+        });
+
+        summary.moves = sortedMoves.slice(0, 10).map((m: any) => ({
+            name: m.move?.name || m.name || '',
+        }));
+    }
+
+    return summary;
 }
 
 /**
  * Summarizes a Pokemon Species API response
  */
 function summarizePokemonSpecies(data: any): JsonObject {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
-
-  const summary: JsonObject = {
-    id: data.id,
-    name: data.name,
-    color: data.color?.name || '',
-    habitat: data.habitat?.name || '',
-    generation: data.generation?.name || '',
-  };
-
-  if (data.evolution_chain?.url) {
-    summary.evolution_chain_url = data.evolution_chain.url;
-  }
-
-  if (Array.isArray(data.flavor_text_entries) && data.flavor_text_entries.length > 0) {
-    const flavorEntry = data.flavor_text_entries.find((e: any) => e.language?.name === 'en');
-    if (flavorEntry) {
-      summary.description = flavorEntry.flavor_text?.replace(/\n/g, ' ').trim() || '';
+    if (!data || typeof data !== 'object') {
+        return data;
     }
-  }
 
-  return summary;
+    const summary: JsonObject = {
+        id: data.id,
+        name: data.name,
+        color: data.color?.name || '',
+        habitat: data.habitat?.name || '',
+        generation: data.generation?.name || '',
+    };
+
+    if (data.evolution_chain?.url) {
+        summary.evolution_chain_url = data.evolution_chain.url;
+    }
+
+    if (Array.isArray(data.flavor_text_entries) && data.flavor_text_entries.length > 0) {
+        const flavorEntry = data.flavor_text_entries.find((e: any) => e.language?.name === 'en');
+        if (flavorEntry) {
+            summary.description = flavorEntry.flavor_text?.replace(/\n/g, ' ').trim() || '';
+        }
+    }
+
+    return summary;
 }
 
 /**
  * Summarizes a Type API response
  */
 function summarizeType(data: any): JsonObject {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
+    if (!data || typeof data !== 'object') {
+        return data;
+    }
 
-  const summary: JsonObject = {
-    id: data.id,
-    name: data.name,
-  };
-
-  if (data.damage_relations) {
-    summary.damage_relations = {
-      double_damage_from: data.damage_relations.double_damage_from?.slice(0, 5).map((t: any) => t.name || '') || [],
-      double_damage_to: data.damage_relations.double_damage_to?.slice(0, 5).map((t: any) => t.name || '') || [],
-      half_damage_from: data.damage_relations.half_damage_from?.slice(0, 5).map((t: any) => t.name || '') || [],
-      half_damage_to: data.damage_relations.half_damage_to?.slice(0, 5).map((t: any) => t.name || '') || [],
-      no_damage_from: data.damage_relations.no_damage_from?.map((t: any) => t.name || '') || [],
-      no_damage_to: data.damage_relations.no_damage_to?.map((t: any) => t.name || '') || [],
+    const summary: JsonObject = {
+        id: data.id,
+        name: data.name,
     };
-  }
 
-  return summary;
+    if (data.damage_relations) {
+        summary.damage_relations = {
+            double_damage_from: data.damage_relations.double_damage_from?.slice(0, 5).map((t: any) => t.name || '') || [],
+            double_damage_to: data.damage_relations.double_damage_to?.slice(0, 5).map((t: any) => t.name || '') || [],
+            half_damage_from: data.damage_relations.half_damage_from?.slice(0, 5).map((t: any) => t.name || '') || [],
+            half_damage_to: data.damage_relations.half_damage_to?.slice(0, 5).map((t: any) => t.name || '') || [],
+            no_damage_from: data.damage_relations.no_damage_from?.map((t: any) => t.name || '') || [],
+            no_damage_to: data.damage_relations.no_damage_to?.map((t: any) => t.name || '') || [],
+        };
+    }
+
+    return summary;
 }
 
 /**
  * Summarizes an Ability API response
  */
 function summarizeAbility(data: any): JsonObject {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
-
-  const summary: JsonObject = {
-    id: data.id,
-    name: data.name,
-    is_main_series: data.is_main_series || false,
-  };
-
-  if (Array.isArray(data.effect_entries) && data.effect_entries.length > 0) {
-    const enEffect = data.effect_entries.find((e: any) => e.language?.name === 'en');
-    if (enEffect) {
-      summary.effect = enEffect.effect || '';
+    if (!data || typeof data !== 'object') {
+        return data;
     }
-  }
 
-  if (Array.isArray(data.flavor_text_entries) && data.flavor_text_entries.length > 0) {
-    const enFlavor = data.flavor_text_entries.find((e: any) => e.language?.name === 'en');
-    if (enFlavor) {
-      summary.flavor_text = enFlavor.flavor_text?.replace(/\n/g, ' ').trim() || '';
+    const summary: JsonObject = {
+        id: data.id,
+        name: data.name,
+        is_main_series: data.is_main_series || false,
+    };
+
+    if (Array.isArray(data.effect_entries) && data.effect_entries.length > 0) {
+        const enEffect = data.effect_entries.find((e: any) => e.language?.name === 'en');
+        if (enEffect) {
+            summary.effect = enEffect.effect || '';
+        }
     }
-  }
 
-  if (Array.isArray(data.pokemon)) {
-    summary.pokemon_with_ability = data.pokemon.slice(0, 10).map((p: any) => ({
-      name: p.pokemon?.name || '',
-      is_hidden: p.is_hidden || false,
-    }));
-  }
+    if (Array.isArray(data.flavor_text_entries) && data.flavor_text_entries.length > 0) {
+        const enFlavor = data.flavor_text_entries.find((e: any) => e.language?.name === 'en');
+        if (enFlavor) {
+            summary.flavor_text = enFlavor.flavor_text?.replace(/\n/g, ' ').trim() || '';
+        }
+    }
 
-  return summary;
+    if (Array.isArray(data.pokemon)) {
+        summary.pokemon_with_ability = data.pokemon.slice(0, 10).map((p: any) => ({
+            name: p.pokemon?.name || '',
+            is_hidden: p.is_hidden || false,
+        }));
+    }
+
+    return summary;
 }
 
 /**
  * Summarizes a Move API response
  */
 function summarizeMove(data: any): JsonObject {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
-
-  const summary: JsonObject = {
-    id: data.id,
-    name: data.name,
-    power: data.power,
-    accuracy: data.accuracy,
-    priority: data.priority || 0,
-    type: data.type?.name || '',
-    category: data.damage_class?.name || '',
-    pp: data.pp || 0,
-  };
-
-  if (Array.isArray(data.effect_entries) && data.effect_entries.length > 0) {
-    const enEffect = data.effect_entries.find((e: any) => e.language?.name === 'en');
-    if (enEffect) {
-      summary.effect = enEffect.effect || '';
-      summary.effect_chance = enEffect.effect_chance || null;
+    if (!data || typeof data !== 'object') {
+        return data;
     }
-  }
 
-  return summary;
+    const summary: JsonObject = {
+        id: data.id,
+        name: data.name,
+        power: data.power,
+        accuracy: data.accuracy,
+        priority: data.priority || 0,
+        type: data.type?.name || '',
+        category: data.damage_class?.name || '',
+        pp: data.pp || 0,
+    };
+
+    if (Array.isArray(data.effect_entries) && data.effect_entries.length > 0) {
+        const enEffect = data.effect_entries.find((e: any) => e.language?.name === 'en');
+        if (enEffect) {
+            summary.effect = enEffect.effect || '';
+            summary.effect_chance = enEffect.effect_chance || null;
+        }
+    }
+
+    return summary;
 }
 
 /**
@@ -257,91 +259,146 @@ const server = new Server(
  */
 const toolDefinitionMap: Map<string, McpToolDefinition> = new Map([
 
-  ["getPokemon", {
-    name: "getPokemon",
-    description: `Get a specific Pokémon by ID or name. Returns summarized data in TOON format (Token-Oriented Object Notation) for token efficiency: id, name, height, weight, types, base stats, abilities, and moves.`,
-    inputSchema: {"type":"object","properties":{"idOrName":{"type":"string","description":"The ID or name of the Pokémon (e.g., 25 or 'pikachu')"}},"required":["idOrName"]},
-    method: "get",
-    pathTemplate: "/pokemon/{idOrName}",
-    executionParameters: [{"name":"idOrName","in":"path"}],
-    requestBodyContentType: undefined,
-    securityRequirements: []
-  }],
-  ["getPokemonSpecies", {
-    name: "getPokemonSpecies",
-    description: `Get Pokémon species information by ID or name. Returns summarized data in TOON format: id, name, color, habitat, generation, evolution chain URL, and English description.`,
-    inputSchema: {"type":"object","properties":{"idOrName":{"type":"string","description":"The ID or name of the Pokémon species (e.g., 25 or 'pikachu')"}},"required":["idOrName"]},
-    method: "get",
-    pathTemplate: "/pokemon-species/{idOrName}",
-    executionParameters: [{"name":"idOrName","in":"path"}],
-    requestBodyContentType: undefined,
-    securityRequirements: []
-  }],
-  ["getType", {
-    name: "getType",
-    description: `Get Pokémon type information by ID or name. Returns TOON format data: id, name, and damage relations (double damage from/to, half damage from/to, no damage from/to).`,
-    inputSchema: {"type":"object","properties":{"idOrName":{"type":"string","description":"The ID or name of the type (e.g., 1 or 'normal')"}},"required":["idOrName"]},
-    method: "get",
-    pathTemplate: "/type/{idOrName}",
-    executionParameters: [{"name":"idOrName","in":"path"}],
-    requestBodyContentType: undefined,
-    securityRequirements: []
-  }],
-  ["getAbility", {
-    name: "getAbility",
-    description: `Get ability information by ID or name. Returns TOON format data: id, name, is_main_series, effect, flavor text, and list of Pokémon with this ability.`,
-    inputSchema: {"type":"object","properties":{"idOrName":{"type":"string","description":"The ID or name of the ability (e.g., 1 or 'static')"}},"required":["idOrName"]},
-    method: "get",
-    pathTemplate: "/ability/{idOrName}",
-    executionParameters: [{"name":"idOrName","in":"path"}],
-    requestBodyContentType: undefined,
-    securityRequirements: []
-  }],
-  ["getMove", {
-    name: "getMove",
-    description: `Get move information by ID or name. Returns TOON format data: id, name, power, accuracy, priority, type, category, pp, and effect description.`,
-    inputSchema: {"type":"object","properties":{"idOrName":{"type":"string","description":"The ID or name of the move (e.g., 1 or 'pound')"}},"required":["idOrName"]},
-    method: "get",
-    pathTemplate: "/move/{idOrName}",
-    executionParameters: [{"name":"idOrName","in":"path"}],
-    requestBodyContentType: undefined,
-    securityRequirements: []
-  }],
+    ["getPokemon", {
+        name: "getPokemon",
+        description: `Get a specific Pokémon by ID or name. Returns summarized data in TOON format (Token-Oriented Object Notation) for token efficiency: id, name, height, weight, types, base stats, abilities, and moves.`,
+        inputSchema: { "type": "object", "properties": { "idOrName": { "type": "string", "description": "The ID or name of the Pokémon (e.g., 25 or 'pikachu')" } }, "required": ["idOrName"] },
+        method: "get",
+        pathTemplate: "/pokemon/{idOrName}",
+        executionParameters: [{ "name": "idOrName", "in": "path" }],
+        requestBodyContentType: undefined,
+        securityRequirements: []
+    }],
+    ["getPokemonSpecies", {
+        name: "getPokemonSpecies",
+        description: `Get Pokémon species information by ID or name. Returns summarized data in TOON format: id, name, color, habitat, generation, evolution chain URL, and English description.`,
+        inputSchema: { "type": "object", "properties": { "idOrName": { "type": "string", "description": "The ID or name of the Pokémon species (e.g., 25 or 'pikachu')" } }, "required": ["idOrName"] },
+        method: "get",
+        pathTemplate: "/pokemon-species/{idOrName}",
+        executionParameters: [{ "name": "idOrName", "in": "path" }],
+        requestBodyContentType: undefined,
+        securityRequirements: []
+    }],
+    ["getType", {
+        name: "getType",
+        description: `Get Pokémon type information by ID or name. Returns TOON format data: id, name, and damage relations (double damage from/to, half damage from/to, no damage from/to).`,
+        inputSchema: { "type": "object", "properties": { "idOrName": { "type": "string", "description": "The ID or name of the type (e.g., 1 or 'normal')" } }, "required": ["idOrName"] },
+        method: "get",
+        pathTemplate: "/type/{idOrName}",
+        executionParameters: [{ "name": "idOrName", "in": "path" }],
+        requestBodyContentType: undefined,
+        securityRequirements: []
+    }],
+    ["getAbility", {
+        name: "getAbility",
+        description: `Get ability information by ID or name. Returns TOON format data: id, name, is_main_series, effect, flavor text, and list of Pokémon with this ability.`,
+        inputSchema: { "type": "object", "properties": { "idOrName": { "type": "string", "description": "The ID or name of the ability (e.g., 1 or 'static')" } }, "required": ["idOrName"] },
+        method: "get",
+        pathTemplate: "/ability/{idOrName}",
+        executionParameters: [{ "name": "idOrName", "in": "path" }],
+        requestBodyContentType: undefined,
+        securityRequirements: []
+    }],
+    ["getMove", {
+        name: "getMove",
+        description: `Get move information by ID or name. Returns TOON format data: id, name, power, accuracy, priority, type, category, pp, and effect description.`,
+        inputSchema: { "type": "object", "properties": { "idOrName": { "type": "string", "description": "The ID or name of the move (e.g., 1 or 'pound')" } }, "required": ["idOrName"] },
+        method: "get",
+        pathTemplate: "/move/{idOrName}",
+        executionParameters: [{ "name": "idOrName", "in": "path" }],
+        requestBodyContentType: undefined,
+        securityRequirements: []
+    }],
 ]);
+
+const promptDefinitionMap = {
+    "pokemon-species-comparison": {
+        name: "pokemon-species-comparison",
+        description: "Compare top-level and species-level data (type, stats, abilities, moves, habitat, color, evolution chain) between two Pokémon",
+        // The spec requires a flat array of arguments instead of a JSON inputSchema
+        arguments: [
+            {
+                name: "pokemon1",
+                description: "The name of the first Pokémon to compare",
+                required: true
+            },
+            {
+                name: "pokemon2",
+                description: "The name of the second Pokémon to compare",
+                required: true
+            }
+        ]
+    }
+};
 
 /**
  * Security schemes from the OpenAPI spec
  */
-const securitySchemes =   {};
+const securitySchemes = {};
 
 /**
  * Setup tool handlers for a server instance
  */
 function setupToolHandlers(server: Server) {
-  logger.debug("Setting up tool handlers", { toolCount: toolDefinitionMap.size });
-  Array.from(toolDefinitionMap.keys()).forEach(toolName => {
-    logger.debug("Registering tool", { toolName });
-  });
+    logger.debug("Setting up tool handlers", { toolCount: toolDefinitionMap.size });
+    Array.from(toolDefinitionMap.keys()).forEach(toolName => {
+        logger.debug("Registering tool", { toolName });
+    });
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const toolsForClient: Tool[] = Array.from(toolDefinitionMap.values()).map(def => ({
-      name: def.name,
-      description: def.description,
-      inputSchema: def.inputSchema
-    }));
-    return { tools: toolsForClient };
-  });
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const toolsForClient: Tool[] = Array.from(toolDefinitionMap.values()).map(def => ({
+            name: def.name,
+            description: def.description,
+            inputSchema: def.inputSchema
+        }));
+        return { tools: toolsForClient };
+    });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<CallToolResult> => {
-    const { name: toolName, arguments: toolArgs } = request.params;
-    logger.setContext('toolName', toolName);
-    const toolDefinition = toolDefinitionMap.get(toolName);
-    if (!toolDefinition) {
-      logger.error(`Unknown tool requested: ${toolName}`);
-      return { content: [{ type: "text", text: `Error: Unknown tool requested: ${toolName}` }] };
-    }
-    return await executeApiTool(toolName, toolDefinition, toolArgs ?? {}, securitySchemes);
-  });
+    // FIX: Add the missing execution handler to resolve the prompt invocation
+    server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+        const { name, arguments: args } = request.params;
+
+        if (name !== "pokemon-species-comparison") {
+            throw new Error(`Prompt not found: ${name}`);
+        }
+
+        // Safely extract parameters passed from the Inspector UI
+        const pokemon1 = args?.pokemon1 ?? "unknown";
+        const pokemon2 = args?.pokemon2 ?? "unknown";
+
+        // Build the context string dynamically using your variables
+        const promptText = `You are a Pokémon species expert. Use \`getPokemon\` for ${pokemon1} and ${pokemon2} to compare: type, stats, abilities, and moves. Use \`getPokemonSpecies\` for ${pokemon1} and ${pokemon2} to compare: habitat, color, and evolution chain. Generate a markdown table and note any advantages/disadvantages.`;
+
+        return {
+            description: "Compare top-level and species-level data (type, stats, abilities, moves, habitat, color, evolution chain) between two Pokémon",
+            messages: [
+                {
+                    role: "user",
+                    content: {
+                        type: "text",
+                        text: promptText
+                    }
+                }
+            ]
+        };
+    });
+
+    server.setRequestHandler(ListPromptsRequestSchema, async () => {
+        return {
+            prompts: Object.values(promptDefinitionMap)
+        };
+    });
+
+    server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<CallToolResult> => {
+        const { name: toolName, arguments: toolArgs } = request.params;
+        logger.setContext('toolName', toolName);
+        const toolDefinition = toolDefinitionMap.get(toolName);
+        if (!toolDefinition) {
+            logger.error(`Unknown tool requested: ${toolName}`);
+            return { content: [{ type: "text", text: `Error: Unknown tool requested: ${toolName}` }] };
+        }
+        return await executeApiTool(toolName, toolDefinition, toolArgs ?? {}, securitySchemes);
+    });
 }
 
 /**
@@ -372,27 +429,27 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
         const clientId = process.env[`OAUTH_CLIENT_ID_SCHEMENAME`];
         const clientSecret = process.env[`OAUTH_CLIENT_SECRET_SCHEMENAME`];
         const scopes = process.env[`OAUTH_SCOPES_SCHEMENAME`];
-        
+
         if (!clientId || !clientSecret) {
             logger.warn(`Missing client credentials for OAuth2 scheme`, { schemeName });
             return null;
         }
-        
+
         // Initialize token cache if needed
         if (typeof global.__oauthTokenCache === 'undefined') {
             global.__oauthTokenCache = {};
         }
-        
+
         // Check if we have a cached token
         const cacheKey = `${schemeName}_${clientId}`;
         const cachedToken = global.__oauthTokenCache[cacheKey];
         const now = Date.now();
-        
+
         if (cachedToken && cachedToken.expiresAt > now) {
             logger.debug(`Using cached OAuth2 token`, { schemeName, expiresInSeconds: Math.floor((cachedToken.expiresAt - now) / 1000) });
             return cachedToken.token;
         }
-        
+
         // Determine token URL based on flow type
         let tokenUrl = '';
         if (scheme.flows?.clientCredentials?.tokenUrl) {
@@ -405,18 +462,18 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
             logger.warn(`No supported OAuth2 flow found`, { schemeName });
             return null;
         }
-        
+
         // Prepare the token request
         let formData = new URLSearchParams();
         formData.append('grant_type', 'client_credentials');
-        
+
         // Add scopes if specified
         if (scopes) {
             formData.append('scope', scopes);
         }
-        
+
         logger.debug(`Requesting OAuth2 token`, { tokenUrl, schemeName });
-        
+
         // Make the token request
         const response = await axios({
             method: 'POST',
@@ -427,18 +484,18 @@ async function acquireOAuth2Token(schemeName: string, scheme: any): Promise<stri
             },
             data: formData.toString()
         });
-        
+
         // Process the response
         if (response.data?.access_token) {
             const token = response.data.access_token;
             const expiresIn = response.data.expires_in || 3600; // Default to 1 hour
-            
+
             // Cache the token
             global.__oauthTokenCache[cacheKey] = {
                 token,
                 expiresAt: now + (expiresIn * 1000) - 60000 // Expire 1 minute early
             };
-            
+
             logger.info(`Successfully acquired OAuth2 token`, { schemeName, expiresInSeconds: expiresIn });
             return token;
         } else {
@@ -468,307 +525,307 @@ async function executeApiTool(
     toolArgs: JsonObject,
     allSecuritySchemes: Record<string, any>
 ): Promise<CallToolResult> {
-  try {
-    // Validate arguments against the input schema
-    let validatedArgs: JsonObject;
     try {
-        const zodSchema = getZodSchemaFromJsonSchema(definition.inputSchema, toolName);
-        const argsToParse = (typeof toolArgs === 'object' && toolArgs !== null) ? toolArgs : {};
-        validatedArgs = zodSchema.parse(argsToParse);
-    } catch (error: unknown) {
-        if (error instanceof ZodError) {
-            const validationErrorMessage = `Invalid arguments for tool '${toolName}': ${error.errors.map(e => `${e.path.join('.')} (${e.code}): ${e.message}`).join(', ')}`;
-            return { content: [{ type: 'text', text: validationErrorMessage }] };
-        } else {
-             const errorMessage = error instanceof Error ? error.message : String(error);
-             return { content: [{ type: 'text', text: `Internal error during validation setup: ${errorMessage}` }] };
-        }
-    }
-
-    // Prepare URL, query parameters, headers, and request body
-    let urlPath = definition.pathTemplate;
-    const queryParams: Record<string, any> = {};
-    const headers: Record<string, string> = { 'Accept': 'application/json' };
-    let requestBodyData: any = undefined;
-
-    // Apply parameters to the URL path, query, or headers
-    definition.executionParameters.forEach((param) => {
-        const value = validatedArgs[param.name];
-        if (typeof value !== 'undefined' && value !== null) {
-            if (param.in === 'path') {
-                urlPath = urlPath.replace(`{${param.name}}`, encodeURIComponent(String(value)));
-            }
-            else if (param.in === 'query') {
-                queryParams[param.name] = value;
-            }
-            else if (param.in === 'header') {
-                headers[param.name.toLowerCase()] = String(value);
+        // Validate arguments against the input schema
+        let validatedArgs: JsonObject;
+        try {
+            const zodSchema = getZodSchemaFromJsonSchema(definition.inputSchema, toolName);
+            const argsToParse = (typeof toolArgs === 'object' && toolArgs !== null) ? toolArgs : {};
+            validatedArgs = zodSchema.parse(argsToParse);
+        } catch (error: unknown) {
+            if (error instanceof ZodError) {
+                const validationErrorMessage = `Invalid arguments for tool '${toolName}': ${error.errors.map(e => `${e.path.join('.')} (${e.code}): ${e.message}`).join(', ')}`;
+                return { content: [{ type: 'text', text: validationErrorMessage }] };
+            } else {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                return { content: [{ type: 'text', text: `Internal error during validation setup: ${errorMessage}` }] };
             }
         }
-    });
 
-    // Ensure all path parameters are resolved
-    if (urlPath.includes('{')) {
-        throw new Error(`Failed to resolve path parameters: ${urlPath}`);
-    }
-    
-    // Construct the full URL
-    const requestUrl = API_BASE_URL ? `${API_BASE_URL}${urlPath}` : urlPath;
+        // Prepare URL, query parameters, headers, and request body
+        let urlPath = definition.pathTemplate;
+        const queryParams: Record<string, any> = {};
+        const headers: Record<string, string> = { 'Accept': 'application/json' };
+        let requestBodyData: any = undefined;
 
-    // Handle request body if needed
-    if (definition.requestBodyContentType && typeof validatedArgs['requestBody'] !== 'undefined') {
-        requestBodyData = validatedArgs['requestBody'];
-        headers['content-type'] = definition.requestBodyContentType;
-    }
-
-
-    // Apply security requirements if available
-    // Security requirements use OR between array items and AND within each object
-    const appliedSecurity = definition.securityRequirements?.find(req => {
-        // Try each security requirement (combined with OR)
-        return Object.entries(req).every(([schemeName, scopesArray]) => {
-            const scheme = allSecuritySchemes[schemeName];
-            if (!scheme) return false;
-            
-            // API Key security (header, query, cookie)
-            if (scheme.type === 'apiKey') {
-                return !!process.env[`API_KEY_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-            }
-            
-            // HTTP security (basic, bearer)
-            if (scheme.type === 'http') {
-                if (scheme.scheme?.toLowerCase() === 'bearer') {
-                    return !!process.env[`BEARER_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+        // Apply parameters to the URL path, query, or headers
+        definition.executionParameters.forEach((param) => {
+            const value = validatedArgs[param.name];
+            if (typeof value !== 'undefined' && value !== null) {
+                if (param.in === 'path') {
+                    urlPath = urlPath.replace(`{${param.name}}`, encodeURIComponent(String(value)));
                 }
-                else if (scheme.scheme?.toLowerCase() === 'basic') {
-                    return !!process.env[`BASIC_USERNAME_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`] && 
-                           !!process.env[`BASIC_PASSWORD_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                else if (param.in === 'query') {
+                    queryParams[param.name] = value;
+                }
+                else if (param.in === 'header') {
+                    headers[param.name.toLowerCase()] = String(value);
                 }
             }
-            
-            // OAuth2 security
-            if (scheme.type === 'oauth2') {
-                // Check for pre-existing token
-                if (process.env[`OAUTH_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`]) {
-                    return true;
+        });
+
+        // Ensure all path parameters are resolved
+        if (urlPath.includes('{')) {
+            throw new Error(`Failed to resolve path parameters: ${urlPath}`);
+        }
+
+        // Construct the full URL
+        const requestUrl = API_BASE_URL ? `${API_BASE_URL}${urlPath}` : urlPath;
+
+        // Handle request body if needed
+        if (definition.requestBodyContentType && typeof validatedArgs['requestBody'] !== 'undefined') {
+            requestBodyData = validatedArgs['requestBody'];
+            headers['content-type'] = definition.requestBodyContentType;
+        }
+
+
+        // Apply security requirements if available
+        // Security requirements use OR between array items and AND within each object
+        const appliedSecurity = definition.securityRequirements?.find(req => {
+            // Try each security requirement (combined with OR)
+            return Object.entries(req).every(([schemeName, scopesArray]) => {
+                const scheme = allSecuritySchemes[schemeName];
+                if (!scheme) return false;
+
+                // API Key security (header, query, cookie)
+                if (scheme.type === 'apiKey') {
+                    return !!process.env[`API_KEY_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
                 }
-                
-                // Check for client credentials for auto-acquisition
-                if (process.env[`OAUTH_CLIENT_ID_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`] &&
-                    process.env[`OAUTH_CLIENT_SECRET_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`]) {
-                    // Verify we have a supported flow
-                    if (scheme.flows?.clientCredentials || scheme.flows?.password) {
+
+                // HTTP security (basic, bearer)
+                if (scheme.type === 'http') {
+                    if (scheme.scheme?.toLowerCase() === 'bearer') {
+                        return !!process.env[`BEARER_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                    }
+                    else if (scheme.scheme?.toLowerCase() === 'basic') {
+                        return !!process.env[`BASIC_USERNAME_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`] &&
+                            !!process.env[`BASIC_PASSWORD_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                    }
+                }
+
+                // OAuth2 security
+                if (scheme.type === 'oauth2') {
+                    // Check for pre-existing token
+                    if (process.env[`OAUTH_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`]) {
                         return true;
                     }
-                }
-                
-                return false;
-            }
-            
-            // OpenID Connect
-            if (scheme.type === 'openIdConnect') {
-                return !!process.env[`OPENID_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-            }
-            
-            return false;
-        });
-    });
 
-    // If we found matching security scheme(s), apply them
-    if (appliedSecurity) {
-        // Apply each security scheme from this requirement (combined with AND)
-        for (const [schemeName, scopesArray] of Object.entries(appliedSecurity)) {
-            const scheme = allSecuritySchemes[schemeName];
-            
-            // API Key security
-            if (scheme?.type === 'apiKey') {
-                const apiKey = process.env[`API_KEY_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-                if (apiKey) {
-                    if (scheme.in === 'header') {
-                        headers[scheme.name.toLowerCase()] = apiKey;
-                        logger.debug(`Applied API key to header`, { schemeName, headerName: scheme.name });
+                    // Check for client credentials for auto-acquisition
+                    if (process.env[`OAUTH_CLIENT_ID_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`] &&
+                        process.env[`OAUTH_CLIENT_SECRET_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`]) {
+                        // Verify we have a supported flow
+                        if (scheme.flows?.clientCredentials || scheme.flows?.password) {
+                            return true;
+                        }
                     }
-                    else if (scheme.in === 'query') {
-                        queryParams[scheme.name] = apiKey;
-                        logger.debug(`Applied API key to query parameter`, { schemeName, paramName: scheme.name });
-                    }
-                    else if (scheme.in === 'cookie') {
-                        // Add the cookie, preserving other cookies if they exist
-                        headers['cookie'] = `${scheme.name}=${apiKey}${headers['cookie'] ? `; ${headers['cookie']}` : ''}`;
-                        logger.debug(`Applied API key to cookie`, { schemeName, cookieName: scheme.name });
+
+                    return false;
+                }
+
+                // OpenID Connect
+                if (scheme.type === 'openIdConnect') {
+                    return !!process.env[`OPENID_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                }
+
+                return false;
+            });
+        });
+
+        // If we found matching security scheme(s), apply them
+        if (appliedSecurity) {
+            // Apply each security scheme from this requirement (combined with AND)
+            for (const [schemeName, scopesArray] of Object.entries(appliedSecurity)) {
+                const scheme = allSecuritySchemes[schemeName];
+
+                // API Key security
+                if (scheme?.type === 'apiKey') {
+                    const apiKey = process.env[`API_KEY_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                    if (apiKey) {
+                        if (scheme.in === 'header') {
+                            headers[scheme.name.toLowerCase()] = apiKey;
+                            logger.debug(`Applied API key to header`, { schemeName, headerName: scheme.name });
+                        }
+                        else if (scheme.in === 'query') {
+                            queryParams[scheme.name] = apiKey;
+                            logger.debug(`Applied API key to query parameter`, { schemeName, paramName: scheme.name });
+                        }
+                        else if (scheme.in === 'cookie') {
+                            // Add the cookie, preserving other cookies if they exist
+                            headers['cookie'] = `${scheme.name}=${apiKey}${headers['cookie'] ? `; ${headers['cookie']}` : ''}`;
+                            logger.debug(`Applied API key to cookie`, { schemeName, cookieName: scheme.name });
+                        }
                     }
                 }
-            } 
-            // HTTP security (Bearer or Basic)
-            else if (scheme?.type === 'http') {
-                if (scheme.scheme?.toLowerCase() === 'bearer') {
-                    const token = process.env[`BEARER_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                // HTTP security (Bearer or Basic)
+                else if (scheme?.type === 'http') {
+                    if (scheme.scheme?.toLowerCase() === 'bearer') {
+                        const token = process.env[`BEARER_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                        if (token) {
+                            headers['authorization'] = `Bearer ${token}`;
+                            logger.debug(`Applied Bearer token`, { schemeName });
+                        }
+                    }
+                    else if (scheme.scheme?.toLowerCase() === 'basic') {
+                        const username = process.env[`BASIC_USERNAME_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                        const password = process.env[`BASIC_PASSWORD_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                        if (username && password) {
+                            headers['authorization'] = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+                            logger.debug(`Applied Basic authentication`, { schemeName });
+                        }
+                    }
+                }
+                // OAuth2 security
+                else if (scheme?.type === 'oauth2') {
+                    // First try to use a pre-provided token
+                    let token = process.env[`OAUTH_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+
+                    // If no token but we have client credentials, try to acquire a token
+                    if (!token && (scheme.flows?.clientCredentials || scheme.flows?.password)) {
+                        logger.debug(`Attempting to acquire OAuth token`, { schemeName });
+                        token = (await acquireOAuth2Token(schemeName, scheme)) ?? '';
+                    }
+
+                    // Apply token if available
                     if (token) {
                         headers['authorization'] = `Bearer ${token}`;
-                        logger.debug(`Applied Bearer token`, { schemeName });
-                    }
-                } 
-                else if (scheme.scheme?.toLowerCase() === 'basic') {
-                    const username = process.env[`BASIC_USERNAME_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-                    const password = process.env[`BASIC_PASSWORD_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-                    if (username && password) {
-                        headers['authorization'] = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-                        logger.debug(`Applied Basic authentication`, { schemeName });
+                        logger.debug(`Applied OAuth2 token`, { schemeName });
+
+                        // List the scopes that were requested, if any
+                        const scopes = scopesArray as string[];
+                        if (scopes && scopes.length > 0) {
+                            logger.debug(`Requested OpenID Connect scopes`, { scopes });
+                        }
                     }
                 }
-            }
-            // OAuth2 security
-            else if (scheme?.type === 'oauth2') {
-                // First try to use a pre-provided token
-                let token = process.env[`OAUTH_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-                
-                // If no token but we have client credentials, try to acquire a token
-                if (!token && (scheme.flows?.clientCredentials || scheme.flows?.password)) {
-                    logger.debug(`Attempting to acquire OAuth token`, { schemeName });
-                    token = (await acquireOAuth2Token(schemeName, scheme)) ?? '';
-                }
-                
-                // Apply token if available
-                if (token) {
-                    headers['authorization'] = `Bearer ${token}`;
-                    logger.debug(`Applied OAuth2 token`, { schemeName });
-                    
-                    // List the scopes that were requested, if any
-                    const scopes = scopesArray as string[];
-                    if (scopes && scopes.length > 0) {
-                        logger.debug(`Requested OpenID Connect scopes`, { scopes });
-                    }
-                }
-            }
-            // OpenID Connect
-            else if (scheme?.type === 'openIdConnect') {
-                const token = process.env[`OPENID_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
-                if (token) {
-                    headers['authorization'] = `Bearer ${token}`;
-                    logger.debug(`Applied OpenID Connect token`, { schemeName });
-                    
-                    // List the scopes that were requested, if any
-                    const scopes = scopesArray as string[];
-                    if (scopes && scopes.length > 0) {
-                        logger.debug(`Requested OAuth2 scopes`, { scopes, schemeName });
+                // OpenID Connect
+                else if (scheme?.type === 'openIdConnect') {
+                    const token = process.env[`OPENID_TOKEN_${schemeName.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`];
+                    if (token) {
+                        headers['authorization'] = `Bearer ${token}`;
+                        logger.debug(`Applied OpenID Connect token`, { schemeName });
+
+                        // List the scopes that were requested, if any
+                        const scopes = scopesArray as string[];
+                        if (scopes && scopes.length > 0) {
+                            logger.debug(`Requested OAuth2 scopes`, { scopes, schemeName });
+                        }
                     }
                 }
             }
         }
-    } 
-    // Log warning if security is required but not available
-    else if (definition.securityRequirements?.length > 0) {
-        // First generate a more readable representation of the security requirements
-        const securityRequirementsString = definition.securityRequirements
-            .map(req => {
-                const parts = Object.entries(req)
-                    .map(([name, scopesArray]) => {
-                        const scopes = scopesArray as string[];
-                        if (scopes.length === 0) return name;
-                        return `${name} (scopes: ${scopes.join(', ')})`;
-                    })
-                    .join(' AND ');
-                return `[${parts}]`;
-            })
-            .join(' OR ');
-            
-        logger.warn(`Tool requires security but no credentials found`, { toolName, securityRequirements: securityRequirementsString });
-    }
-    
+        // Log warning if security is required but not available
+        else if (definition.securityRequirements?.length > 0) {
+            // First generate a more readable representation of the security requirements
+            const securityRequirementsString = definition.securityRequirements
+                .map(req => {
+                    const parts = Object.entries(req)
+                        .map(([name, scopesArray]) => {
+                            const scopes = scopesArray as string[];
+                            if (scopes.length === 0) return name;
+                            return `${name} (scopes: ${scopes.join(', ')})`;
+                        })
+                        .join(' AND ');
+                    return `[${parts}]`;
+                })
+                .join(' OR ');
 
-    // Prepare the axios request configuration
-    const config: AxiosRequestConfig = {
-      method: definition.method.toUpperCase(), 
-      url: requestUrl, 
-      params: queryParams, 
-      headers: headers,
-      ...(requestBodyData !== undefined && { data: requestBodyData }),
-    };
+            logger.warn(`Tool requires security but no credentials found`, { toolName, securityRequirements: securityRequirementsString });
+        }
 
-    // Log request info (doesn't affect MCP output)
-    logger.setContext('endpoint', config.url);
-    logger.info(`Executing tool`, { method: config.method, url: config.url });
-    
-    // Execute the request
-    const response = await axios(config);
 
-    // Process and format the response
-    let responseText = '';
-    const contentType = response.headers['content-type']?.toString().toLowerCase() || '';
-    
-    // Handle JSON responses
-    if (contentType.includes('application/json') && typeof response.data === 'object' && response.data !== null) {
-         try {
-             // Use TOON format for all Pokemon tools
-             if (toolName === 'getPokemon') {
-                 const summarized = summarizePokemon(response.data);
-                 responseText = encodeToon(summarized);
-             } else if (toolName === 'getPokemonSpecies') {
-                 const summarized = summarizePokemonSpecies(response.data);
-                 responseText = encodeToon(summarized);
-             } else if (toolName === 'getType') {
-                 const summarized = summarizeType(response.data);
-                 responseText = encodeToon(summarized);
-             } else if (toolName === 'getAbility') {
-                 const summarized = summarizeAbility(response.data);
-                 responseText = encodeToon(summarized);
-             } else if (toolName === 'getMove') {
-                 const summarized = summarizeMove(response.data);
-                 responseText = encodeToon(summarized);
-             } else {
-                 // For other tools, use standard JSON formatting
-                 responseText = JSON.stringify(response.data, null, 2);
-             }
-         } catch (e) { 
-             responseText = "[Stringify Error]"; 
-         }
-    } 
-    // Handle string responses
-    else if (typeof response.data === 'string') { 
-         responseText = response.data; 
-    }
-    // Handle other response types
-    else if (response.data !== undefined && response.data !== null) { 
-         responseText = String(response.data); 
-    }
-    // Handle empty responses
-    else { 
-         responseText = `(Status: ${response.status} - No body content)`; 
-    }
-    
-    // Return formatted response
-    return { 
-        content: [ 
-            { 
-                type: "text", 
-                text: `API Response (Status: ${response.status}):\n${responseText}` 
-            } 
-        ], 
-    };
+        // Prepare the axios request configuration
+        const config: AxiosRequestConfig = {
+            method: definition.method.toUpperCase(),
+            url: requestUrl,
+            params: queryParams,
+            headers: headers,
+            ...(requestBodyData !== undefined && { data: requestBodyData }),
+        };
 
-  } catch (error: unknown) {
-    // Handle errors during execution
-    let errorMessage: string;
-    
-    // Format Axios errors specially
-    if (axios.isAxiosError(error)) { 
-        errorMessage = formatApiError(error); 
+        // Log request info (doesn't affect MCP output)
+        logger.setContext('endpoint', config.url);
+        logger.info(`Executing tool`, { method: config.method, url: config.url });
+
+        // Execute the request
+        const response = await axios(config);
+
+        // Process and format the response
+        let responseText = '';
+        const contentType = response.headers['content-type']?.toString().toLowerCase() || '';
+
+        // Handle JSON responses
+        if (contentType.includes('application/json') && typeof response.data === 'object' && response.data !== null) {
+            try {
+                // Use TOON format for all Pokemon tools
+                if (toolName === 'getPokemon') {
+                    const summarized = summarizePokemon(response.data);
+                    responseText = encodeToon(summarized);
+                } else if (toolName === 'getPokemonSpecies') {
+                    const summarized = summarizePokemonSpecies(response.data);
+                    responseText = encodeToon(summarized);
+                } else if (toolName === 'getType') {
+                    const summarized = summarizeType(response.data);
+                    responseText = encodeToon(summarized);
+                } else if (toolName === 'getAbility') {
+                    const summarized = summarizeAbility(response.data);
+                    responseText = encodeToon(summarized);
+                } else if (toolName === 'getMove') {
+                    const summarized = summarizeMove(response.data);
+                    responseText = encodeToon(summarized);
+                } else {
+                    // For other tools, use standard JSON formatting
+                    responseText = JSON.stringify(response.data, null, 2);
+                }
+            } catch (e) {
+                responseText = "[Stringify Error]";
+            }
+        }
+        // Handle string responses
+        else if (typeof response.data === 'string') {
+            responseText = response.data;
+        }
+        // Handle other response types
+        else if (response.data !== undefined && response.data !== null) {
+            responseText = String(response.data);
+        }
+        // Handle empty responses
+        else {
+            responseText = `(Status: ${response.status} - No body content)`;
+        }
+
+        // Return formatted response
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `API Response (Status: ${response.status}):\n${responseText}`
+                }
+            ],
+        };
+
+    } catch (error: unknown) {
+        // Handle errors during execution
+        let errorMessage: string;
+
+        // Format Axios errors specially
+        if (axios.isAxiosError(error)) {
+            errorMessage = formatApiError(error);
+        }
+        // Handle standard errors
+        else if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        // Handle unexpected error types
+        else {
+            errorMessage = 'Unexpected error: ' + String(error);
+        }
+
+        // Log error
+        logger.error(`Error during execution of tool`, { errorMessage });
+
+        // Return error message to client
+        return { content: [{ type: "text", text: errorMessage }] };
     }
-    // Handle standard errors
-    else if (error instanceof Error) { 
-        errorMessage = error.message; 
-    }
-    // Handle unexpected error types
-    else { 
-        errorMessage = 'Unexpected error: ' + String(error); 
-    }
-    
-    // Log error
-    logger.error(`Error during execution of tool`, { errorMessage });
-    
-    // Return error message to client
-    return { content: [{ type: "text", text: errorMessage }] };
-  }
 }
 
 
@@ -776,25 +833,25 @@ async function executeApiTool(
  * Main function to start the server
  */
 async function main() {
-  // Create a server factory function that creates new Server instances per connection
-  const serverFactory = () => {
-    const newServer = new Server(
-      { name: SERVER_NAME, version: SERVER_VERSION },
-      { capabilities: { tools: {} } }
-    );
-    // Setup tool handlers on the new server instance
-    setupToolHandlers(newServer);
-    return newServer;
-  };
-  
-  try {
-    logger.info("Starting MCP server", { port: 3001, apiBaseUrl: API_BASE_URL });
-    await setupStreamableHttpServer(serverFactory, 3001);
-    logger.info("MCP server started successfully", { port: 3001 });
-  } catch (error) {
-    logger.error("Error setting up StreamableHTTP server", { error: error instanceof Error ? error.message : String(error) });
-    process.exit(1);
-  }
+    // Create a server factory function that creates new Server instances per connection
+    const serverFactory = () => {
+        const newServer = new Server(
+            { name: SERVER_NAME, version: SERVER_VERSION },
+            { capabilities: { prompts: {}, tools: {} } }
+        );
+        // Setup tool handlers on the new server instance
+        setupToolHandlers(newServer);
+        return newServer;
+    };
+
+    try {
+        logger.info("Starting MCP server", { port: 3001, apiBaseUrl: API_BASE_URL });
+        await setupStreamableHttpServer(serverFactory, 3001);
+        logger.info("MCP server started successfully", { port: 3001 });
+    } catch (error) {
+        logger.error("Error setting up StreamableHTTP server", { error: error instanceof Error ? error.message : String(error) });
+        process.exit(1);
+    }
 }
 
 /**
@@ -811,8 +868,8 @@ process.on('SIGTERM', cleanup);
 
 // Start the server
 main().catch((error) => {
-  logger.error("Fatal error in main execution", { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
-  process.exit(1);
+    logger.error("Fatal error in main execution", { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
+    process.exit(1);
 });
 
 /**
@@ -827,25 +884,25 @@ function formatApiError(error: AxiosError): string {
         message = `API Error: Status ${error.response.status} (${error.response.statusText || 'Status text not available'}). `;
         const responseData = error.response.data;
         const MAX_LEN = 200;
-        if (typeof responseData === 'string') { 
-            message += `Response: ${responseData.substring(0, MAX_LEN)}${responseData.length > MAX_LEN ? '...' : ''}`; 
+        if (typeof responseData === 'string') {
+            message += `Response: ${responseData.substring(0, MAX_LEN)}${responseData.length > MAX_LEN ? '...' : ''}`;
         }
-        else if (responseData) { 
-            try { 
-                const jsonString = JSON.stringify(responseData); 
-                message += `Response: ${jsonString.substring(0, MAX_LEN)}${jsonString.length > MAX_LEN ? '...' : ''}`; 
-            } catch { 
-                message += 'Response: [Could not serialize data]'; 
-            } 
+        else if (responseData) {
+            try {
+                const jsonString = JSON.stringify(responseData);
+                message += `Response: ${jsonString.substring(0, MAX_LEN)}${jsonString.length > MAX_LEN ? '...' : ''}`;
+            } catch {
+                message += 'Response: [Could not serialize data]';
+            }
         }
-        else { 
-            message += 'No response body received.'; 
+        else {
+            message += 'No response body received.';
         }
     } else if (error.request) {
         message = 'API Network Error: No response received from server.';
         if (error.code) message += ` (Code: ${error.code})`;
-    } else { 
-        message += `API Request Setup Error: ${error.message}`; 
+    } else {
+        message += `API Request Setup Error: ${error.message}`;
     }
     return message;
 }
@@ -858,14 +915,14 @@ function formatApiError(error: AxiosError): string {
  * @returns Zod schema
  */
 function getZodSchemaFromJsonSchema(jsonSchema: any, toolName: string): z.ZodTypeAny {
-    if (typeof jsonSchema !== 'object' || jsonSchema === null) { 
-        return z.object({}).passthrough(); 
+    if (typeof jsonSchema !== 'object' || jsonSchema === null) {
+        return z.object({}).passthrough();
     }
     try {
         const zodSchemaString = jsonSchemaToZod(jsonSchema);
         const zodSchema = eval(zodSchemaString);
-        if (typeof zodSchema?.parse !== 'function') { 
-            throw new Error('Eval did not produce a valid Zod schema.'); 
+        if (typeof zodSchema?.parse !== 'function') {
+            throw new Error('Eval did not produce a valid Zod schema.');
         }
         return zodSchema as z.ZodTypeAny;
     } catch (err: any) {

--- a/mcp-pokemon/src/streamable-http.ts
+++ b/mcp-pokemon/src/streamable-http.ts
@@ -16,7 +16,7 @@ import { SERVER_NAME, SERVER_VERSION } from './index.js';
 
 // Import logger utilities
 import { logger } from './logger.js';
-
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 
 // Constants
 const SESSION_ID_HEADER_NAME = "mcp-session-id";
@@ -28,8 +28,8 @@ const JSON_RPC = "2.0";
 class MCPStreamableHttpServer {
   serverFactory: () => Server;
   // Store active transports by session ID
-  transports: {[sessionId: string]: StreamableHTTPServerTransport} = {};
-  
+  private transports: Record<string, WebStandardStreamableHTTPServerTransport> = {};
+
   constructor(serverFactory: () => Server) {
     this.serverFactory = serverFactory;
   }
@@ -51,100 +51,108 @@ class MCPStreamableHttpServer {
   async handlePostRequest(c: any) {
     const sessionId = c.req.header(SESSION_ID_HEADER_NAME) || undefined;
     
-    // Set session context for all logs within this request
     if (sessionId) {
       logger.setContext('sessionId', sessionId);
     }
     
-    logger.info(`POST request received`, { sessionId: sessionId || 'none' });
-    
+    // DIAGNOSTIC 1: Log incoming request details completely
+    logger.info(`[MCP DEBUG] POST request received`, { 
+      sessionId: sessionId || 'none',
+      url: c.req.raw.url,
+      headers: Object.fromEntries(c.req.raw.headers.entries()) 
+    });
+
     try {
-      // Read body from the original request
-      const bodyText = await c.req.text();
-      let body: any;
-      
+      const rawRequest = c.req.raw;
+
+      // DIAGNOSTIC 2: Safely inspect the JSON payload without consuming the stream
       try {
-        body = JSON.parse(bodyText);
-      } catch {
-        body = null;
+        const inspectClone = rawRequest.clone();
+        const payloadText = await inspectClone.text();
+        logger.info(`[MCP DEBUG] Incoming JSON-RPC Payload:`, { payload: payloadText });
+      } catch (e) {
+        logger.warn(`[MCP DEBUG] Could not inspect incoming request body text`, { error: String(e) });
       }
-      
-      // Check if this is an initialize request
-      const isInitialize = !sessionId && this.isInitializeRequest(body);
-      
-      // Create a completely fresh Request object with the body as a new stream
-      // This avoids any stream locking issues from Hono's request handling
-      const freshRequest = new Request(c.req.raw.url, {
-        method: c.req.raw.method,
-        headers: c.req.raw.headers,
-        body: bodyText,
-      });
-      
-      // Now convert this fresh request to Node.js req/res
-      const { req, res } = toReqRes(freshRequest);
-      
-      // Reuse existing transport if we have a session ID
+
+      // Reuse existing transport if we have an active session ID
       if (sessionId && this.transports[sessionId]) {
         const transport = this.transports[sessionId];
-        
-        // Handle the request with the transport
-        await transport.handleRequest(req, res, body);
-        
-        // Convert Node.js response back to Fetch Response
-        return toFetchResponse(res);
-      }
-      
-      // Create new transport for initialize requests
-      if (isInitialize) {
-        logger.clearContext();
-        logger.info("Creating new StreamableHTTP transport for initialize request");
-        
-        // Create a new Server instance for this connection
-        const server = this.serverFactory();
-        
-        const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => uuid(),
-        });
-        
-        // Add error handler for debug purposes
-        transport.onerror = (err) => {
-          logger.error('StreamableHTTP transport error', { error: err instanceof Error ? err.message : String(err) });
-        };
-        
-        // Connect the transport to this new MCP server
-        await server.connect(transport);
-        
-        // Handle the request with the transport
-        await transport.handleRequest(req, res, body);
-        
-        // Store the transport if we have a session ID
-        const newSessionId = transport.sessionId;
-        if (newSessionId) {
-          logger.info(`New session established`, { newSessionId });
-          this.transports[newSessionId] = transport;
-          
-          // Set up clean-up for when the transport is closed
-          transport.onclose = () => {
-            logger.info(`Session closed`, { newSessionId });
-            delete this.transports[newSessionId];
-          };
+        logger.info(`[MCP DEBUG] Routing to existing session: ${sessionId}`);
+
+        try {
+          const webResponse = await transport.handleRequest(rawRequest);
+          logger.info(`[MCP DEBUG] Existing session successfully produced response`, { status: webResponse.status });
+          return webResponse;
+        } catch (transportErr) {
+          logger.error(`[MCP CRITICAL] Existing transport execution failed!`, {
+            error: transportErr instanceof Error ? transportErr.message : String(transportErr),
+            stack: transportErr instanceof Error ? transportErr.stack : 'No stack trace'
+          });
+          throw transportErr;
         }
-        
-        // Convert Node.js response back to Fetch Response
-        return toFetchResponse(res);
       }
+
+      // New Connection Initialization Routing
+      logger.info("[MCP DEBUG] Initializing fresh connection pipeline...");
+      const server = this.serverFactory();
       
-      // Invalid request (no session ID and not initialize)
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => uuid(),
+      });
+
+      // DIAGNOSTIC 3: Explicitly bind the transport error hook
+      transport.onerror = (err) => {
+        logger.error('[MCP TRANSPORT ASYNC ERROR]', { 
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : 'No stack trace available'
+        });
+      };
+
+      // DIAGNOSTIC 4: Wrap the Server Connection handshake
+      logger.info("[MCP DEBUG] Connecting transport layer to MCP Server instance...");
+      await server.connect(transport);
+      logger.info("[MCP DEBUG] Server-to-transport handshake successful");
+
+      // DIAGNOSTIC 5: Capture execution point of the actual request resolution
+      logger.info("[MCP DEBUG] Handing over execution to transport.handleRequest()...");
+      let webResponse: Response;
+      try {
+        webResponse = await transport.handleRequest(rawRequest);
+      } catch (handleErr) {
+        logger.error(`[MCP CRITICAL] transport.handleRequest() crashed!`, {
+          error: handleErr instanceof Error ? handleErr.message : String(handleErr),
+          stack: handleErr instanceof Error ? handleErr.stack : 'No stack trace'
+        });
+        throw handleErr;
+      }
+
+      logger.info(`[MCP DEBUG] HandleRequest succeeded. Status: ${webResponse.status}`);
+
+      const newSessionId = transport.sessionId;
+      if (newSessionId) {
+        logger.info(`[MCP DEBUG] New session ID registered`, { newSessionId });
+        this.transports[newSessionId] = transport;
+
+        transport.onclose = () => {
+          logger.info(`[MCP DEBUG] Transport Session explicitly closed`, { newSessionId });
+          delete this.transports[newSessionId];
+        };
+      }
+
+      return webResponse;
+
+    } catch (error: any) {
       logger.clearContext();
+      
+      // DIAGNOSTIC 6: Catch absolute root context traces
+      logger.error('Error handling MCP request - Top Level Failure', { 
+        message: error?.message || String(error),
+        stack: error?.stack || 'No runtime stack trace',
+        rawErrorObj: JSON.stringify(error, Object.getOwnPropertyNames(error))
+      });
+
       return c.json(
-        this.createErrorResponse("Bad Request: invalid session ID or method."),
-        400
-      );
-    } catch (error) {
-      logger.clearContext();
-      logger.error('Error handling MCP request', { error: error instanceof Error ? error.message : String(error) });
-      return c.json(
-        this.createErrorResponse("Internal server error."),
+        this.createErrorResponse(`Internal server error: ${error?.message || String(error)}`),
         500
       );
     }

--- a/src/example/pokemon_mcp.py
+++ b/src/example/pokemon_mcp.py
@@ -146,6 +146,33 @@ async def get_mcp_tools():
         raise
 
 
+async def get_mcp_prompt(prompt_name: str, arguments: dict):
+    """Auto-discover prompt from MCP server."""
+    client = MultiServerMCPClient(
+        {
+            "pokemon": {
+                "transport": "streamable_http",
+                "url": f"{POKEMON_MCP_SERVER_HOST}/mcp",
+            }
+        }
+    )
+    try:
+        messages = await client.get_prompt(
+            server_name="pokemon",
+            prompt_name=prompt_name,
+            arguments=arguments
+        )
+
+        compiled_prompt_text = None
+        if messages and isinstance(messages, list):
+            compiled_prompt_text = messages[0].content
+
+        return compiled_prompt_text
+    except Exception as e:
+        st.error(f"Failed to load MCP prompt: {e}")
+        raise
+
+
 def create_chain(model_name: str, tools):
     """Create a Deep Agents agent with auto-discovered MCP tools."""
     if not tools:
@@ -178,43 +205,98 @@ def create_chain(model_name: str, tools):
 
 
 def process_query(agent, query: str, langfuse_handler=None):
-    """Process a user query through the deep agent."""
     try:
-        # Deep Agents expects messages format
+        comparison_terms = [" and ", " to ", " with "]
+        if "compare" in query.lower() and any(
+            term in query.lower() for term in comparison_terms
+        ):
+            st.info("Detected comparison query pattern. Routing through MCP prompt for Pokémon species comparison.")  # noqa: E501
+            clean_query = query.lower().replace("compare", "").strip()
+            if " to " in clean_query:
+                clean_query = clean_query.replace(" to ", " and ")
+            elif " with " in clean_query:
+                clean_query = clean_query.replace(" with ", " and ")
+            parts = [p.strip() for p in clean_query.split(" and ")]
+
+            if len(parts) >= 2:
+                pokemon1_str = parts[0]
+                pokemon2_str = parts[1]
+
+                compiled_prompt_text = asyncio.run(
+                    get_mcp_prompt("pokemon-species-comparison", {
+                        "pokemon1": pokemon1_str,
+                        "pokemon2": pokemon2_str}))
+
+                # st.info(f"Compiled Prompt Text:\n{compiled_prompt_text}")
+
+                if compiled_prompt_text:
+                    config = {"callbacks": [langfuse_handler] if langfuse_handler else None}  # noqa: E501
+
+                    # Pipe compiled instruction into Deep Agent!
+                    agent_response = agent.invoke({
+                        "messages": [{
+                            "role": "user",
+                            "content": compiled_prompt_text
+                        }]
+                    }, config=config)
+
+                    messages = agent_response.get("messages", [])
+                    if messages:
+                        last_message = messages[-1]
+                        if isinstance(last_message, dict):
+                            answer = last_message.get("content", "No response")
+                        else:
+                            answer = getattr(
+                                last_message, 'content', str(last_message))
+                    else:
+                        answer = "No response"
+
+                    return {
+                        "answer": answer,
+                        "intermediate_steps": agent_response.get("intermediate_steps", [])  # noqa: E501
+                    }
+                else:
+                    return {
+                        "answer": "Error: Extracted prompt template context returned empty string.",  # noqa: E501
+                        "intermediate_steps": []
+                    }
+            else:
+                return {
+                    "answer": "Could not identify two valid Pokémon name tokens inside the query text pattern.",  # noqa: E501
+                    "intermediate_steps": []
+                }
+
+        # Fallback route execution path for non-comparison operations
         config = {
-            "callbacks": [langfuse_handler] if langfuse_handler else None,
-        }
-
+            "callbacks": [langfuse_handler] if langfuse_handler else None}
         response = agent.invoke({
-            "messages": [{"role": "user", "content": query}]
-        }, config=config)
+            "messages": [{"role": "user", "content": query}]}, config=config)
 
-        # Extract the final answer from the last message
         messages = response.get("messages", [])
         if messages:
             last_message = messages[-1]
-            # Handle both dict and message object
             if isinstance(last_message, dict):
                 answer = last_message.get("content", "No response")
             else:
-                # It's a message object (AIMessage, etc.)
-                answer = getattr(last_message, 'content',
-                                 str(last_message))
+                answer = getattr(last_message, 'content', str(last_message))
         else:
             answer = "No response"
 
         return {
             "answer": answer,
-            "intermediate_steps": response.get("intermediate_steps", []),
+            "intermediate_steps": response.get("intermediate_steps", [])
         }
     except Exception as e:
         error_msg = str(e)
         st.error(f"Error processing query: {error_msg}")
-        return {"answer": f"Error: {error_msg}",
-                "intermediate_steps": []}
+        return {
+            "answer": f"Error running query loop harness: {error_msg}",
+            "intermediate_steps": []
+        }
 
 
-def handle_pokemon_mcp(st, model_name: str, langfuse_handler=None):
+def handle_pokemon_mcp(
+        st, model_name: str, langfuse_handler=None):
     """Handle the Pokémon MCP example UI."""
     st.header("🎮 PokéAPI via MCP Server (Deep Agents)")
     st.markdown(
@@ -229,7 +311,12 @@ standardized tools that Deep Agents can use intelligently.
 - Query type information and effectiveness
 - Find abilities and their effects
 - Get move data and power
-"""
+
+**Available Prompts:** Auto-discovered from the MCP server:
+- Pokémon species comparison prompt
+    - Ask a comparison question like "Compare Pikachu and Bulbasaur"
+    - The system will detect the comparison pattern, extract the Pokémon names, and route through the specialized MCP prompt to generate a comprehensive comparison using the relevant tools.
+"""  # noqa: E501
     )
 
     # Load tools from MCP server (async)

--- a/tests/integration/test_pokemon_mcp.py
+++ b/tests/integration/test_pokemon_mcp.py
@@ -88,3 +88,63 @@ class TestPokemonMCPEndToEnd:
         # Verify we got a valid response (not an error)
         assert not answer.lower().startswith("error"), \
             f"Got error response: {answer}"
+
+    @pytest.mark.integration
+    def test_pokemon_mcp_compare_prompt(self):
+        """Test Pokemon MCP dynamic comparison prompt end-to-end"""
+        from example.pokemon_mcp import (create_chain, process_query,
+                                         get_mcp_tools)
+
+        # Skip if Ollama not available
+        if not OLLAMA_HOST:
+            pytest.skip("OLLAMA_HOST not set")
+
+        # Check if any models are available
+        try:
+            response = requests.get(f"{OLLAMA_HOST}/api/tags", timeout=5)
+            if response.status_code != 200:
+                pytest.fail("Ollama service not available")
+
+            models = response.json().get("models", [])
+            if not models:
+                pytest.fail("No Ollama models found")
+
+            # Prefer llama model (supports tool calling)
+            model_names = [m["name"] for m in models]
+            llama_models = [m for m in model_names if "llama" in m.lower()]
+
+            if llama_models:
+                model_name = llama_models[0]
+            else:
+                # Skip if no llama model available
+                msg = (f"No llama model found. Available: "
+                       f"{', '.join(model_names)}")
+                pytest.skip(msg)
+
+        except requests.exceptions.RequestException:
+            pytest.fail("Ollama service not available")
+
+        # Step 1: Load MCP tools from Pokemon server
+        tools, _ = asyncio.run(get_mcp_tools())
+
+        # Step 2: Create Deep Agent with loaded tools
+        agent = create_chain(model_name, tools)
+        assert agent is not None
+        assert hasattr(agent, 'invoke')
+
+        # Step 3: Process a comparison query end-to-end
+        result = process_query(agent, "Compare Pikachu and Bulbasaur")
+
+        # Verify response structure
+        assert isinstance(result, dict)
+        assert "answer" in result
+        assert "intermediate_steps" in result
+
+        # Verify answer quality
+        answer = result["answer"]
+        assert isinstance(answer, str)
+        assert len(answer) > 0
+
+        # Verify we got a valid response (not an error)
+        assert not answer.lower().startswith("error"), \
+            f"Got error response: {answer}"


### PR DESCRIPTION
## 🚀 Feature: Pokémon Comparison Prompt Support

### ✅ Description
Adds support for Model Context Protocol (MCP) prompts to enable Pokémon comparison functionality, including:
- New `GetPromptRequestSchema`/`ListPromptsRequestSchema` integration
- End-to-end example implementation in Python
- Integration test for validation

### 📁 Changed Files
```diff
+ mcp-pokemon/src/index.ts              # Core prompt integration
+ mcp-pokemon/src/streamable-http.ts    # Streaming server updates
+ src/example/pokemon_mcp.py            # New example implementation
+ tests/integration/test_pokemon_mcp.py # Integration test
```

### 🔧 Key Changes
1. **Prompt System Integration**
   - Added support for listing and retrieving prompts via MCP
   - Updated server to handle prompt-based interactions

2. **Example Implementation**
   ```python
   # src/example/pokemon_mcp.py
   # Demonstrates full workflow from prompt retrieval to result processing